### PR TITLE
Use custom ProgressTextAdapter for progress

### DIFF
--- a/circularprogressindicator/src/main/java/antonkozyriatskyi/circularprogressindicator/CircularProgressIndicator.java
+++ b/circularprogressindicator/src/main/java/antonkozyriatskyi/circularprogressindicator/CircularProgressIndicator.java
@@ -78,6 +78,8 @@ public class CircularProgressIndicator extends View {
 
     private ValueAnimator progressAnimator;
 
+    private ProgressTextAdapter progressTextAdapter;
+
     public CircularProgressIndicator(Context context) {
         super(context);
         init(context, null);
@@ -338,6 +340,9 @@ public class CircularProgressIndicator extends View {
 
     // Adds delimiter, prefix and suffix if needed
     private String formatProgressText(int currentProgress) {
+        if (progressTextAdapter != null) {
+            return progressTextAdapter.formatText(currentProgress);
+        }
 
         StringBuilder sb = new StringBuilder(String.valueOf(currentProgress).length());
 
@@ -523,6 +528,15 @@ public class CircularProgressIndicator extends View {
         invalidate();
     }
 
+    public void setProgressTextAdapter(@Nullable ProgressTextAdapter progressTextAdapter) {
+        this.progressTextAdapter = progressTextAdapter;
+
+        progressText = formatProgressText(progressValue);
+
+        requestLayout();
+        invalidate();
+    }
+
     @ColorInt
     public int getProgressColor() {
         return progressPaint.getColor();
@@ -587,5 +601,9 @@ public class CircularProgressIndicator extends View {
     @Nullable
     public String getProgressTextSuffix() {
         return progressTextSuffix;
+    }
+
+    public interface ProgressTextAdapter {
+        String formatText(int currentProgress);
     }
 }

--- a/example/src/main/java/antonkozyriatskyi/circularprogressindicatorexample/MainActivity.java
+++ b/example/src/main/java/antonkozyriatskyi/circularprogressindicatorexample/MainActivity.java
@@ -57,7 +57,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 dotColor.setEnabled(isChecked);
             }
         });
-
+        CheckBox useCustomTextAdapter = findViewById(R.id.cb_custom_text_adapter);
+        useCustomTextAdapter.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                circularProgress.setProgressTextAdapter(isChecked ? TIME_TEXT_ADAPTER : null);
+            }
+        });
     }
 
     @Override
@@ -133,4 +139,28 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 break;
         }
     }
+
+    private static final CircularProgressIndicator.ProgressTextAdapter TIME_TEXT_ADAPTER = new CircularProgressIndicator.ProgressTextAdapter() {
+        @Override
+        public String formatText(int time) {
+            int hours = time / 3600;
+            time %= 3600;
+            int minutes = time / 60;
+            int seconds = time % 60;
+            StringBuilder sb = new StringBuilder();
+            if (hours < 10) {
+                sb.append(0);
+            }
+            sb.append(hours).append(":");
+            if (minutes < 10) {
+                sb.append(0);
+            }
+            sb.append(minutes).append(":");
+            if (seconds < 10) {
+                sb.append(0);
+            }
+            sb.append(seconds);
+            return sb.toString();
+        }
+    };
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -74,7 +74,6 @@
                 android:min="0"
                 android:progress="8" />
 
-
             <CheckBox
                 android:id="@+id/cb_draw_dot"
                 android:layout_width="match_parent"
@@ -82,6 +81,13 @@
                 android:layout_marginLeft="8dp"
                 android:checked="true"
                 android:text="Enable dot" />
+
+            <CheckBox
+                android:id="@+id/cb_custom_text_adapter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:text="Use custom text adapter (HH:MM:SS)" />
 
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
It is very useful to enable formatting progress text in appropriate way.
For example, convert given `int progress` to formatted time `HH:MM:SS`
So that's why programmer can set it's own ProgressTextAdapter that handles progress text formatting.

I also added simple adapter for time formatting inside demo activity