### PR TITLE
Add setProgress method with optional animation

### DIFF
--- a/circularprogressindicator/src/main/java/antonkozyriatskyi/circularprogressindicator/CircularProgressIndicator.java
+++ b/circularprogressindicator/src/main/java/antonkozyriatskyi/circularprogressindicator/CircularProgressIndicator.java
@@ -377,6 +377,21 @@ public class CircularProgressIndicator extends View {
         setProgress(currentProgress, maxProgressValue);
     }
 
+    public void setProgress(double current, double max, boolean animate) {
+        if (animate) {
+            setProgress(current, max);
+        } else {
+            final double finalAngle;
+            if (direction == DIRECTION_COUNTERCLOCKWISE) {
+                finalAngle = -(current / max * 360);
+            } else {
+                finalAngle = current / max * 360;
+            }
+            sweepAngle = (int) finalAngle;
+            invalidateEverything();
+        }
+    }
+
     public void setProgress(double current, double max) {
         final double finalAngle;
 


### PR DESCRIPTION
If I'm not mistaken, the current solution only allows animation to be enabled or disabled
when initialising the view. This allows it to be set on each `setProgress()` call if desired as long as it is set to `true` initially.